### PR TITLE
Remove question when deactivating plugin / 24h certificate expiry

### DIFF
--- a/pretix_covid_certificates/__init__.py
+++ b/pretix_covid_certificates/__init__.py
@@ -26,6 +26,7 @@ class PluginApp(PluginConfig):
 
     def uninstalled(self, event):
         from pretix.base.models import Question
+
         # Upon deactivation of the plugin, we are removing all products associated with the
         # question. If we didn't do this, pretixSCAN will keep asking the question - possibly
         # with no way to answer it.

--- a/pretix_covid_certificates/__init__.py
+++ b/pretix_covid_certificates/__init__.py
@@ -3,9 +3,9 @@ from django.utils.translation import gettext_lazy
 try:
     from pretix.base.plugins import PluginConfig
 except ImportError:
-    raise RuntimeError("Please use pretix 3.6 or above to run this plugin!")
+    raise RuntimeError("Please use pretix 4.2.0.dev1 or above to run this plugin!")
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 class PluginApp(PluginConfig):
@@ -19,10 +19,27 @@ class PluginApp(PluginConfig):
         visible = True
         version = __version__
         category = "INTEGRATION"
-        compatibility = "pretix>=3.6.0"
+        compatibility = "pretix>=4.2.0.dev1"
 
     def ready(self):
         from . import signals  # NOQA
+
+    def uninstalled(self, event):
+        from pretix.base.models import Question
+        # Upon deactivation of the plugin, we are removing all products associated with the
+        # question. If we didn't do this, pretixSCAN will keep asking the question - possibly
+        # with no way to answer it.
+        #
+        # Ideally, there should be only a single question per event that has the identifier
+        # 'pretix_covid_certificates_question'. But better not assume anything that could be
+        # screwed up though manual tampering.
+        questions = Question.objects.filter(
+            event=event,
+            identifier='pretix_covid_certificates_question'
+        )
+
+        for question in questions:
+            question.items.set([])
 
 
 default_app_config = "pretix_covid_certificates.PluginApp"

--- a/pretix_covid_certificates/tasks.py
+++ b/pretix_covid_certificates/tasks.py
@@ -1,0 +1,14 @@
+from django_scopes import scopes_disabled
+from pretix.base.models import Event, QuestionAnswer
+from pretix.celery_app import app
+
+
+@app.task
+@scopes_disabled()
+def expire_certificate_answers(event):
+    event = Event.objects.get(pk=event)
+    QuestionAnswer.objects.filter(
+        question__event=event,
+        question__identifier='pretix_covid_certificates_question',
+    ).delete()
+    return event.organizer.slug, event.slug

--- a/pretix_covid_certificates/views.py
+++ b/pretix_covid_certificates/views.py
@@ -208,6 +208,17 @@ class CovidCertificatesSettingsForm(SettingsForm):
                     'cannot be processed automatically.')
     )
 
+    covid_certificates_recheck_every_24h = forms.BooleanField(
+        label=_('Recheck status every 24h'),
+        required=False,
+        help_text=_("By default, a participant's status is assumed to be valid for the duration of the whole event. "
+                    "Activating this option will purge all recorded verifications every 24 hours and prompt for "
+                    "another verification upon the next ticket scan. Unless you scan the same ticket multiple days in "
+                    "a row, you will not need to activate this. Please note that activating this option will not allow "
+                    "you to run statistics regarding the frequency of presented proofs as this data will be purged "
+                    "every 24 hours.")
+    )
+
 
 class CovidCertificatesSettings(EventSettingsViewMixin, EventSettingsFormView):
     model = Event


### PR DESCRIPTION
This should be merged with the next release of pretix core so the plugin can leverage the `uninstalled()`-routine.

We could also forgo this requirement and keep the plugin as compatible with pretix>=3.6 - the plugin itself would work, just the automatic cleanup upon plugin deactivation would not fire...

------

This also includes a new option to expire the QuestionAnswers every 24h hours. We should probably keep an eye on the performance of this operation and - if required - offload it onto a separate cronjob similar to the covid-shredder.